### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Ubiqiti UAP Controller
 
 # Use this repo
-docker run -d --privileged --name uap --net=host eszz/unifi
+docker run -d --privileged --name uap --net=host eszz/unify
 
 # Login to Unify Controller
 http://host-ip:8080


### PR DESCRIPTION
Hi,

I just fixed a typo in the docker image name in your README.md which caused the docker run command to fail.

Greetings
Peter